### PR TITLE
Update CyrLCDconverter.cpp

### DIFF
--- a/CyrLCDconverter.cpp
+++ b/CyrLCDconverter.cpp
@@ -230,6 +230,7 @@ char ConvertToCyrLCD::cConvertToCyrLCD (unsigned char ucChar)
 		case 124: {ucResult = 0xc4; break;}
 		case 125: {ucResult = 0xc5; break;}
 		case 126: {ucResult = 0xc6; break;}
+		case 127: {ucResult = 0xc7; break;} // "я"		
 		default: ucResult = 0x00; 			
 	}
 	return ucResult;


### PR DESCRIPTION
Некорректно отображалась буква "я" из-за отсутствия этой строки.